### PR TITLE
fix: 自定义渠道转发 Anthropic 模型时正确解析缓存 token

### DIFF
--- a/types/common.go
+++ b/types/common.go
@@ -14,6 +14,11 @@ type Usage struct {
 	PromptTokensDetails     PromptTokensDetails     `json:"prompt_tokens_details"`
 	CompletionTokensDetails CompletionTokensDetails `json:"completion_tokens_details"`
 
+	// Anthropic-style top-level cache fields returned by some OpenAI-compatible
+	// gateways when proxying Anthropic models (e.g. cache_creation_input_tokens).
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+
 	ExtraTokens  map[string]int          `json:"-"`
 	ExtraBilling map[string]ExtraBilling `json:"-"`
 	TextBuilder  strings.Builder         `json:"-"`
@@ -34,6 +39,16 @@ func (u *Usage) GetExtraTokens() map[string]int {
 	// 缓存数据
 	if u.PromptTokensDetails.CachedTokens > 0 && u.ExtraTokens[config.UsageExtraCache] == 0 {
 		u.ExtraTokens[config.UsageExtraCache] = u.PromptTokensDetails.CachedTokens
+	}
+
+	// Anthropic-style top-level cache fields (from OpenAI-compatible gateways
+	// proxying Anthropic models). Only used as fallback when the standard
+	// prompt_tokens_details fields are not already populated.
+	if u.CacheCreationInputTokens > 0 && u.PromptTokensDetails.CachedWriteTokens == 0 {
+		u.PromptTokensDetails.CachedWriteTokens = u.CacheCreationInputTokens
+	}
+	if u.CacheReadInputTokens > 0 && u.PromptTokensDetails.CachedReadTokens == 0 {
+		u.PromptTokensDetails.CachedReadTokens = u.CacheReadInputTokens
 	}
 
 	// 输入音频


### PR DESCRIPTION
## 关联 Issue

Closes #51

## 问题

自定义渠道（type=8）通过 OpenAI 兼容网关转发 Anthropic 模型时，上游返回的 `usage` 中包含 Anthropic 风格的顶层字段：

```json
{
  "usage": {
    "cache_creation_input_tokens": 1234,
    "cache_read_input_tokens": 5678,
    "prompt_tokens_details": {
      "cached_tokens": 0
    }
  }
}
```

当前 OpenAI provider 只解析 `prompt_tokens_details.cached_tokens`，不处理顶层的 Anthropic 风格字段，导致缓存统计丢失。

## 修改

- 在 `types.Usage` 中新增 `CacheCreationInputTokens` 和 `CacheReadInputTokens` 两个 JSON 字段
- 在 `GetExtraTokens()` 中增加 fallback 逻辑：当标准字段为空时，从顶层 Anthropic 字段回填 `CachedWriteTokens` / `CachedReadTokens`

改动很小，只动了 `types/common.go` 一个文件，不影响已有的 Claude provider 逻辑（Claude provider 有自己的 `ClaudeUsageToOpenaiUsage` 转换）。